### PR TITLE
Add support for API rate limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
 - isort --check-only --recursive --diff .
 - flake8 --jobs=2 .
-- pep257 --verbose --explain --source --count
+- pycodestyle
 - coverage run --source=closeio -m 'pytest'
 after_success: coveralls
 deploy:

--- a/closeio/__init__.py
+++ b/closeio/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 __author__ = 'Denis Cornehl'
 __email__ = 'denis.cornehl@gmail.com'
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 
 
 try:

--- a/closeio/closeio.py
+++ b/closeio/closeio.py
@@ -462,7 +462,7 @@ class CloseIO(object):
         try:
             self.find_user_id(email)
             return True
-        except:
+        except Exception:
             return False
 
     @parse_response

--- a/closeio/exceptions.py
+++ b/closeio/exceptions.py
@@ -6,3 +6,29 @@ from __future__ import (
 
 class CloseIOError(Exception):
     pass
+
+
+class RateLimitError(CloseIOError):
+    """
+    Close.io API rate limit error.
+
+    Attributes:
+        message (str): e.g.: "API call count exceeded for this 30 second window"
+        rate_reset (int): Seconds remaining before this enforcement window ends.
+        rate_limit (int): Request limit enforced for this endpoint.
+        rate_window (int): Number of seconds in enforcement window.
+
+    """
+
+    def __init__(self, message, rate_reset, rate_limit, rate_window, *args, **kwargs):
+        self.message = message
+        self.rate_reset = rate_reset
+        self.rate_limit = rate_limit
+        self.rate_window = rate_window
+        super(RateLimitError, self).__init__(*args, **kwargs)
+
+    def __str__(self):
+        return self.message
+
+    def __unicode__(self):
+        return self.__str__()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ first==2.0.1              # via pip-tools
 flake8==3.3.0
 isort==4.2.5
 mccabe==0.6.1 # via flake8
-pep257==0.7.0
+pydocstyle==1.1.1
 pep8-naming==0.4.1
 pep8==1.7.0               # via flake8
 pip-tools==1.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,13 @@ statistics = true
 show-source = true
 exclude = */migrations/*,docs/*,env/*
 
-[pep257]
+[pycodestyle]
+max-line-length = 99
+statistics = true
+show-source = true
+exclude = */migrations/*,docs/*,env/*
+
+[pydocstyle]
 add-ignore = D100,D101,D102,D103,D104,D105
 
 [coverage:run]


### PR DESCRIPTION
Close.io introduced API
[rate limits](https://developer.close.io/#ratelimits).
Limit errors are cast into a new error type, that make reacting to
rate limit errors easier.