### PR TITLE
Fix #113 -- Add rate_limit_type attribute

### DIFF
--- a/closeio/__init__.py
+++ b/closeio/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 __author__ = 'Denis Cornehl'
 __email__ = 'denis.cornehl@gmail.com'
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 
 try:

--- a/closeio/exceptions.py
+++ b/closeio/exceptions.py
@@ -20,12 +20,13 @@ class RateLimitError(CloseIOError):
 
     """
 
-    def __init__(self, message, rate_reset, rate_limit, rate_window, *args, **kwargs):
+    def __init__(self, message, rate_reset, rate_limit, rate_window, rate_limit_type, **kwargs):
         self.message = message
         self.rate_reset = rate_reset
         self.rate_limit = rate_limit
         self.rate_window = rate_window
-        super(RateLimitError, self).__init__(*args, **kwargs)
+        self.rate_limit_type = rate_limit_type
+        super(RateLimitError, self).__init__()
 
     def __str__(self):
         return self.message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from closeio.exceptions import RateLimitError
+
+
+class TestExceptions:
+    def test_rate_limit_error(self):
+        closeio_error_response = {
+            'error': {'message': 'API call count exceeded for this period', 'rate_reset': 0.870663,
+                      'rate_limit': 40, 'rate_window': 1, 'rate_limit_type': 'key'}
+        }
+        with pytest.raises(RateLimitError) as exc:
+            raise RateLimitError(**closeio_error_response['error'])
+
+        assert exc.value.message is 'API call count exceeded for this period'


### PR DESCRIPTION
* Add rate_limit_type to RateLimitError
* Do not pass any arguments to RateLimitError super init method, to avoid problems with API updates.