### PR TITLE
Replace stale .next() in testing stub and update create_export stub with missing fields

### DIFF
--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -522,7 +522,7 @@ class CloseIOStub(object):
         exports = self._data('exports', [])
         export_id = int(id)
 
-        export = (item for item in exports if item["id"] == export_id).next()
+        export = next((item for item in exports if item["id"] == export_id))
 
         if not export:
             raise CloseIOError()

--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -534,6 +534,8 @@ class CloseIOStub(object):
         exports = self._data('exports', [])
         export = dict(
             format=format,
+            status='done',
+            download_url='https://example.com',
             type='leads',
             query=query,
         )


### PR DESCRIPTION
1. Since Python 3.2 `next(generator)` should be used instead of `generator.next()`
2. `create_lead_export` stub was missing `status` and `download_url` fields. https://developer.close.io/#exports