### PR TITLE
Add ORGANIZATION_ID setting to prevent requests being sent from wrong organization

### DIFF
--- a/closeio/conf.py
+++ b/closeio/conf.py
@@ -1,5 +1,6 @@
 """
 Additional settings for Django.
+
 ``CLOSEIO_ORGANIZATION_ID`` (required):
     Each Closeio webhook contains organization id, pointing the origin of the request.
     This can be used as an extra protection and distinguish between staging and production orgs.

--- a/closeio/conf.py
+++ b/closeio/conf.py
@@ -1,0 +1,17 @@
+"""
+Additional settings for Django.
+``CLOSEIO_ORGANIZATION_ID`` (required):
+    Each Closeio webhook contains organization id, pointing the origin of the request.
+    This can be used as an extra protection and distinguish between staging and production orgs.
+    .. note:: See https://developer.close.io/#organizations
+"""
+from appconf import AppConf
+from django.conf import settings  # NoQA
+
+__all__ = ('settings',)
+
+
+class CloseioConf(AppConf):
+    class Meta:
+        prefix = 'CLOSEIO'
+        required = ['ORGANIZATION_ID']

--- a/closeio/contrib/django/views.py
+++ b/closeio/contrib/django/views.py
@@ -10,6 +10,7 @@ from django.views.generic import View
 from closeio import utils
 
 from . import signals
+from ...conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,12 @@ class CloseIOWebHook(View):
         except KeyError:
             logger.exception("CloseIO webhook request could not be dispatched.")
             return HttpResponseBadRequest()
+
+        # here we are checking which organization request comes from
+        organization_id = data.get('organization_id')
+        if organization_id != settings.CLOSEIO_ORGANIZATION_ID:
+            logger.warning("CloseIO webhook request from wrong organization: %s", organization_id)
+            return HttpResponse()
 
         data_to_send = dict(
             instance=data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+django-appconf
 python-dateutil>=2.2
 requests>=2.2.1
 six>=1.6.1

--- a/tests/djangoapp/conftest.py
+++ b/tests/djangoapp/conftest.py
@@ -20,5 +20,6 @@ def pytest_configure():
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
         ),
+        CLOSEIO_ORGANIZATION_ID='test_org_id'
     )
     django.setup()


### PR DESCRIPTION
This PR adds extra check to a webhook handler to check an organization id.
If it does not match the setting, we just respond without any action.