### PR TITLE
Make several testing stub methods tz aware

### DIFF
--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -2,7 +2,7 @@ import copy
 import itertools
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from closeio.utils import CloseIOError, Item, parse_response
 
@@ -126,7 +126,7 @@ class CloseIOStub(object):
             data['id'] = str(len(leads) + 1)
 
         data['organization_id'] = 'xx'
-        data['date_created'] = datetime.utcnow()
+        data['date_created'] = datetime.now(timezone.utc)
 
         for idx, contact in enumerate(data.get('contacts', [])):
             if not contact.get('id'):
@@ -309,8 +309,8 @@ class CloseIOStub(object):
             'text': text,
             'due_date': due_date.isoformat() if due_date else None,
             'is_complete': is_complete,
-            'date_created': datetime.utcnow().isoformat(),
-            'date_updated': datetime.utcnow().isoformat(),
+            'date_created': datetime.now(timezone.utc).isoformat(),
+            'date_updated': datetime.now(timezone.utc).isoformat(),
         }
 
         tasks[lead_id].append(task)
@@ -488,7 +488,7 @@ class CloseIOStub(object):
             data['id'] = str(len(opportunity_keys) + 1)
 
         data['organization_id'] = 'xx'
-        data['date_created'] = datetime.utcnow()
+        data['date_created'] = datetime.now(timezone.utc)
 
         opportunities[data['id']] = data
         opportunity_keys[data['id']] = data


### PR DESCRIPTION
### Description
Real Closeio API during lead and task creation provides datetimes with TZ data,
so to be accurate we need to update our testing stub.


### How to test
You can create a task and will see the response you'll get:
```
In [13]: closeio.create_task(lead_id='YOUR_LEAD_ID', assigned_to='YOUR_USER_ID', text='PRtest')
Out[13]:
{'_type': 'lead',
 'assigned_to': 'HIDDEN',
 'assigned_to_name': 'HIDDEN',
 'contact_id': None,
 'contact_name': None,
 'created_by': 'HIDDEN',
 'created_by_name': 'HIDDEN',
 'date': datetime.date(2018, 5, 31),
 'date_created': datetime.datetime(2018, 5, 31, 15, 4, 25, 274000, tzinfo=tzutc()),
 'date_updated': datetime.datetime(2018, 5, 31, 15, 4, 25, 274000, tzinfo=tzutc()),
 'due_date': None,
 'id': 'HIDDEN',
 'is_complete': False,
 'is_dateless': True,
 'lead_id': 'HIDDEN',
 'lead_name': 'HIDDEN',
 'object_id': None,
 'object_type': None,
 'organization_id': 'HIDDEN',
 'text': 'PRtest',
 'updated_by': 'HIDDEN',
 'updated_by_name': 'HIDDEN',
 'view': 'inbox'}
```