### PR TITLE
Change default Django version, deploy to pypi only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   global:
   - secure: eO08tZokK+Etpp4ISvxVaWHe5tN6PC/SzLHcltqgvqRYa7L9zY5NKQjiY5LvUw1onnbbSPMnTabFWrcw3VtoQ1he5M2NbqqTSLTxT9dSWXhy6KRymNXVkEv4Ar6WWiQDUPlyMY7XTG35G5jo6C3LBer5FRKDpEAPlw51z4TyML0=
   matrix:
-  - DJANGO="https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django"
   - DJANGO="https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django"
+  - DJANGO="https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz#egg=django"
 matrix:
   allow_failures:
@@ -29,6 +29,7 @@ deploy:
   password:
     secure: EbCAfnLxHzVgyPe/4f1w5wbgBMrEjiPw/olfaDS0kIJjNFuAuWGiqyVQaSPgLsBteD9dYUuU/O95eVy1W5tYFySTc8FEXXXI7YBTMHZN+aFQzFoBcvE6g5npvPAdUU0W53g+13wiAUI9tMFTnOf0rG585qmzMEu0NY6R2dEOtTo=
   on:
+    skip_existing: true
     tags: true
     distributions: sdist bdist_wheel
     repo: Thermondo/closeio


### PR DESCRIPTION
Apparently, there is an option (not in docs yet) to skip deployment to pypi,
if the package is already there: https://github.com/travis-ci/dpl/pull/752
That should fix all master builds where one job is always failing because of deployment attempt.