### PR TITLE
Fix Travis PyPI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ after_success:
 - codecov
 deploy:
   provider: pypi
+  distributions: sdist bdist_wheel
   skip_existing: true
   user: codingjoe
   password:
     secure: EbCAfnLxHzVgyPe/4f1w5wbgBMrEjiPw/olfaDS0kIJjNFuAuWGiqyVQaSPgLsBteD9dYUuU/O95eVy1W5tYFySTc8FEXXXI7YBTMHZN+aFQzFoBcvE6g5npvPAdUU0W53g+13wiAUI9tMFTnOf0rG585qmzMEu0NY6R2dEOtTo=
   on:
     tags: true
-    distributions: sdist bdist_wheel
     repo: Thermondo/closeio


### PR DESCRIPTION
`distributions` flag was wrongly set under `on` flag.
This PR moves it one level up.
See https://docs.travis-ci.com/user/deployment/pypi/#uploading-different-distributions


P.S. Do we still use your PyPI account here, or we can/should switch to Thermondo one?