### PR TITLE
 add delete method for activities & fix testing stub

### DIFF
--- a/closeio/closeio.py
+++ b/closeio/closeio.py
@@ -292,16 +292,16 @@ class CloseIO(object):
 
     @parse_response
     @handle_errors
+    def create_activity_call(self, **kwargs):
+        return self._api.activity.call.post(kwargs)
+
+    @parse_response
+    @handle_errors
     def get_activity_email(self, lead_id):
         return paginate(
             self._api.activity.email.get,
             lead_id=lead_id,
         )
-
-    @parse_response
-    @handle_errors
-    def create_activity_call(self, **kwargs):
-        return self._api.activity.call.post(kwargs)
 
     @parse_response
     @handle_errors
@@ -329,6 +329,21 @@ class CloseIO(object):
         return paginate(
             self._api.activity.get,
             **kwargs)
+
+    @parse_response
+    @handle_errors
+    def delete_activity_email(self, activity_id):
+        return self._api.activity.email(activity_id).delete()
+
+    @parse_response
+    @handle_errors
+    def delete_activity_call(self, activity_id):
+        return self._api.activity.call(activity_id).delete()
+
+    @parse_response
+    @handle_errors
+    def delete_activity_note(self, activity_id):
+        return self._api.activity.note(activity_id).delete()
 
     @parse_response
     @handle_errors

--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -295,6 +295,39 @@ class CloseIOStub(object):
         notes[lead_id].append(note)
 
     @parse_response
+    def delete_activity_email(self, activity_id):
+        emails = self._data('activity_emails', {})
+
+        for lead_id, email_list in emails.items():
+            for email in email_list:
+                if email['id'] == activity_id:
+                    emails[lead_id].remove(email)
+                    return True
+        raise CloseIOError()
+
+    @parse_response
+    def delete_activity_call(self, activity_id):
+        calls = self._data('activity_calls', {})
+
+        for lead_id, call_list in calls.items():
+            for call in call_list:
+                if call['id'] == activity_id:
+                    calls[lead_id].remove(call)
+                    return True
+        raise CloseIOError()
+
+    @parse_response
+    def delete_activity_note(self, activity_id):
+        notes = self._data('activity_note', {})
+
+        for lead_id, note_list in notes.items():
+            for note in note_list:
+                if note['id'] == activity_id:
+                    notes[lead_id].remove(note)
+                    return True
+        raise CloseIOError()
+
+    @parse_response
     def create_task(self, lead_id, assigned_to, text, due_date=None,
                     is_complete=False):
         tasks = self._data('tasks', {})

--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -278,6 +278,7 @@ class CloseIOStub(object):
     def create_activity_call(self, **kwargs):
         calls = self._data('activity_calls', {})
         call = kwargs
+        call['id'] = 'acti_{}'.format(uuid.uuid4().hex)
         lead_id = call['lead_id']
 
         if lead_id not in calls:
@@ -286,8 +287,11 @@ class CloseIOStub(object):
         calls[lead_id].append(call)
 
     @parse_response
-    def create_activity_note(self, lead_id, note):
+    def create_activity_note(self, **kwargs):
         notes = self._data('activity_notes', {})
+        note = kwargs
+        note['id'] = 'acti_{}'.format(uuid.uuid4().hex)
+        lead_id = note['lead_id']
 
         if lead_id not in notes:
             notes[lead_id] = []
@@ -318,7 +322,7 @@ class CloseIOStub(object):
 
     @parse_response
     def delete_activity_note(self, activity_id):
-        notes = self._data('activity_note', {})
+        notes = self._data('activity_notes', {})
 
         for lead_id, note_list in notes.items():
             for note in note_list:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -94,7 +94,7 @@ class TestEndToEnd(object):
         response = client.get_lead(lead['id'])
         assert all(False for k in lead if k not in response), dict(response)
 
-    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.flaky(reruns=5)
     def test_get_leads(self, client, lead):
         query = 'name:{name}'.format(**lead)
         response = client.get_leads(query=query)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -176,6 +176,47 @@ class TestEndToEnd(object):
             response = client.create_activity_email(**call)
             assert all(False for k in call if k not in response), dict(response)
 
+    def test_delete_activity_email(self, client, lead):
+        with open(os.path.join(FIXTURE_DIR, 'email.json')) as f:
+            email = utils.parse(json.load(f))
+            email.update({
+                'lead_id': lead['id'],
+            })
+            response = client.create_activity_email(**email)
+            activity_id = response['id']
+
+            response = client.delete_activity_email(activity_id)
+            assert response is True
+
+            assert list(client.get_activity_email(lead['id'])) == []
+
+    def test_delete_activity_call(self, client, lead):
+        with open(os.path.join(FIXTURE_DIR, 'call.json')) as f:
+            call = utils.parse(json.load(f))
+            call.update({
+                'lead_id': lead['id'],
+            })
+            response = client.create_activity_call(**call)
+            activity_id = response['id']
+
+            response = client.delete_activity_call(activity_id)
+            assert response is True
+
+            assert list(client.get_activity_call(lead['id'])) == []
+
+    def test_delete_activity_note(self, client, lead):
+        note = {
+            'note': 'this is a test note.',
+            'lead_id': lead['id'],
+        }
+        response = client.create_activity_note(**note)
+        activity_id = response['id']
+
+        response = client.delete_activity_note(activity_id)
+        assert response is True
+
+        assert list(client.get_activity_note(lead['id'])) == []
+
     def test_create_lead_export(self, client, random_string):
         export = client.create_lead_export(random_string)
         assert export


### PR DESCRIPTION
This PR adds delete methods for all activities: 
* `delete_activity_email` 
* `delete_activity_call` 
* `delete_activity_note`

Furthermore, this fixes the testing stub. The methods `get_activity_call` and `get_activity_note` did not return records with IDs.

Note: this PR should most likely be merged keeping separate commits.