### PR TITLE
add support for event log API

### DIFF
--- a/closeio/closeio.py
+++ b/closeio/closeio.py
@@ -6,7 +6,7 @@ from requests.adapters import HTTPAdapter
 
 from closeio.exceptions import CloseIOError
 from closeio.utils import (
-    DummyCookieJar, convert, handle_errors, paginate, parse_response
+    DummyCookieJar, convert, handle_errors, paginate, parse_response, paginate_via_cursor
 )
 
 logger = logging.getLogger(__name__)
@@ -507,3 +507,11 @@ class CloseIO(object):
     @handle_errors
     def get_export(self, id):
         return self._api.export(id).get()
+
+    @parse_response
+    @handle_errors
+    def get_event_logs(self, **kwargs):
+        return paginate_via_cursor(
+            self._api.event.get,
+            **kwargs
+        )

--- a/closeio/closeio.py
+++ b/closeio/closeio.py
@@ -6,7 +6,8 @@ from requests.adapters import HTTPAdapter
 
 from closeio.exceptions import CloseIOError
 from closeio.utils import (
-    DummyCookieJar, convert, handle_errors, paginate, parse_response, paginate_via_cursor
+    DummyCookieJar, convert, handle_errors, paginate, paginate_via_cursor,
+    parse_response
 )
 
 logger = logging.getLogger(__name__)

--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -5,8 +5,9 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
-from closeio.utils import CloseIOError, Item, parse_response
 from dateutil.parser import parse
+
+from closeio.utils import CloseIOError, Item, parse_response
 
 threadlocal = threading.local()
 

--- a/closeio/utils.py
+++ b/closeio/utils.py
@@ -160,6 +160,32 @@ def paginate(func, *args, **kwargs):
             skip += limit
 
 
+def paginate_via_cursor(func, *args, **kwargs):
+    cursor = ''
+    limit = 50
+
+    while True:
+        kwargs['_cursor'] = cursor
+        kwargs['_limit'] = limit
+
+        with convert_errors():
+            response = func(*args, **kwargs)
+
+        if not isinstance(response, dict):
+            raise CloseIOError(
+                'close.io response is not a dict, '
+                'so most likely could not be parsed. \n'
+                'body "{}"'.format(response)
+            )
+
+        for item in response['data']:
+            yield item
+
+        cursor = response['cursor_next']
+        if not cursor:
+            break
+
+
 class DummyCookieJar(object):
     def __init__(self, policy=None):
         pass

--- a/tests/test_testing_stub.py
+++ b/tests/test_testing_stub.py
@@ -1,0 +1,49 @@
+import datetime
+
+from closeio.contrib.testing_stub import CloseIOStub
+
+
+class TestCloseIOStub:
+    def test_record_and_retrieve_event_logs(self):
+        client = CloseIOStub()
+
+        task1 = client.create_task(lead_id='x1', assigned_to='y1', text='z1')
+        client.delete_task(task_id=task1['id'])
+
+        assert list(client.get_event_logs()) == []
+
+        with client.record_logs():
+            task2 = client.create_task(lead_id='x2', assigned_to='y2', text='z2')
+            client.delete_task(task_id=task2['id'])
+            pause = datetime.datetime.utcnow().isoformat()
+            task3 = client.create_task(lead_id='x3', assigned_to='y3', text='z3')
+            client.delete_task(task_id=task3['id'])
+
+        logs = list(client.get_event_logs())
+        assert len(logs) == 4
+        assert logs[0]['action'] == 'deleted'
+        assert logs[0]['object_id'] == task3['id']
+        assert logs[1]['action'] == 'created'
+        assert logs[1]['object_id'] == task3['id']
+        assert logs[2]['action'] == 'deleted'
+        assert logs[2]['object_id'] == task2['id']
+        assert logs[3]['action'] == 'created'
+        assert logs[3]['object_id'] == task2['id']
+
+        logs = list(client.get_event_logs(action='created'))
+        assert len(logs) == 2
+
+        logs = list(client.get_event_logs(action='deleted'))
+        assert len(logs) == 2
+
+        logs = list(client.get_event_logs(object_type='task.lead'))
+        assert len(logs) == 4
+        assert logs[0]['object_id'] == task3['id']
+        assert logs[1]['object_id'] == task3['id']
+        assert logs[2]['object_id'] == task2['id']
+        assert logs[3]['object_id'] == task2['id']
+
+        logs = list(client.get_event_logs(object_type='task.lead', date_updated__gt=pause))
+        assert len(logs) == 2
+        assert logs[0]['object_id'] == task3['id']
+        assert logs[1]['object_id'] == task3['id']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from closeio.utils import paginate_via_cursor
+
+
+def test_paginate_via_cursor():
+    responses = {
+        '': {'cursor_next': '11111', 'data': [{'id': 1}, {'id': 2}]},
+        '11111': {'cursor_next': '22222', 'data': [{'id': 3}, {'id': 4}]},
+        '22222': {'cursor_next': '', 'data': [{'id': 5}, {'id': 6}]}
+    }
+
+    def test_function(**kwargs):
+        cursor = kwargs.get('_cursor')
+        return responses[cursor]
+
+    response = paginate_via_cursor(test_function)
+    assert list(response) == [{'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}, {'id': 5}, {'id': 6}]


### PR DESCRIPTION
This PR adds support for the [event log API](https://developer.close.io/#event-log).
The testing stub will not record event logs by default but I added a context manager that can be used to record logs while testing so that the `get_event_logs` method of the testing stub will return useful data. However, for now only task creation and deletion is supported as possible event logs.