### PR TITLE
fix return value in testing stub for creating activities

### DIFF
--- a/closeio/contrib/testing_stub.py
+++ b/closeio/contrib/testing_stub.py
@@ -340,6 +340,7 @@ class CloseIOStub(object):
             calls[lead_id] = []
 
         calls[lead_id].append(call)
+        return call
 
     @parse_response
     def create_activity_note(self, **kwargs):
@@ -352,6 +353,7 @@ class CloseIOStub(object):
             notes[lead_id] = []
 
         notes[lead_id].append(note)
+        return note
 
     @parse_response
     def delete_activity_email(self, activity_id):

--- a/tests/test_testing_stub.py
+++ b/tests/test_testing_stub.py
@@ -3,7 +3,7 @@ import datetime
 from closeio.contrib.testing_stub import CloseIOStub
 
 
-class TestCloseIOStub:
+class TestEventLogs:
     def test_record_and_retrieve_event_logs(self):
         client = CloseIOStub()
 
@@ -47,3 +47,47 @@ class TestCloseIOStub:
         assert len(logs) == 2
         assert logs[0]['object_id'] == task3['id']
         assert logs[1]['object_id'] == task3['id']
+
+
+class TestCreateActivities:
+    def test_create_activity_note(self):
+        client = CloseIOStub()
+
+        kwargs = {
+            'note': 'this is a test note.',
+            'lead_id': 'lead_s6vHFTK1TSRoH6otXOexWDO9jM4xyb1kELHDoU7Fdsp',
+        }
+        response = client.create_activity_note(**kwargs)
+        assert response['id'].startswith('acti_')
+
+    def test_create_activity_call(self):
+        client = CloseIOStub()
+
+        kwargs = {
+            'direction': 'outbound',
+            'status': 'completed',
+            'note': 'call notes go here',
+            'duration': 153,
+            'lead_id': 'lead_s6vHFTK1TSRoH6otXOexWDO9jM4xyb1kELHDoU7Fdsp',
+        }
+        response = client.create_activity_call(**kwargs)
+        assert response['id'].startswith('acti_')
+
+    def test_create_activity_email(self):
+        client = CloseIOStub()
+
+        kwargs = {
+            'subject': 'test subject',
+            'sender': 'sender@example.com',
+            'to': ['recipient+1@example.com'],
+            'bcc': [],
+            'cc': [],
+            'status': 'draft',
+            'body_text': 'test',
+            'body_html': 'test',
+            'attachments': [],
+            'template_id': None,
+            'lead_id': 'lead_s6vHFTK1TSRoH6otXOexWDO9jM4xyb1kELHDoU7Fdsp',
+        }
+        response = client.create_activity_email(**kwargs)
+        assert response['id'].startswith('acti_')


### PR DESCRIPTION
When creating activities like notes or calls, the API returns the data of the created activity, just like it's documented [here](https://developer.close.io/#activities-create-a-note-activity).
This library returns the response correctly but the testing stub did not return anything and therefore was not reflecting the behaviour of the library. 
This PR fixes this and adds some tests for this case.