### PR TITLE
Catch JSONDecodeError when checking webhook signature

### DIFF
--- a/closeio/contrib/django/utils.py
+++ b/closeio/contrib/django/utils.py
@@ -32,7 +32,10 @@ def webhook_signature_valid(request):
     Args:
         request: an instance of Django's ``HttpRequest`` object
     """
-    payload = json.loads(request.body)
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return False
     subscription_id = payload.get('subscription_id')
     if not subscription_id:
         return False

--- a/tests/djangoapp/test_utils.py
+++ b/tests/djangoapp/test_utils.py
@@ -90,3 +90,9 @@ class TestCloseioWebhookPermission:
         headers['HTTP_CLOSE_SIG_TIMESTAMP'] = '1234567890'
         request = rf.post('/some/webhook/view', payload, **headers)
         assert webhook_signature_valid(request) is False
+
+    def test_invalid_because_of_invalid_json(self, rf, webhook_settings, headers):
+        """Should fail if the request body is not valid JSON."""
+        payload = b''
+        request = rf.post('/some/webhook/view', payload, **headers)
+        assert webhook_signature_valid(request) is False


### PR DESCRIPTION
This change catches an error that would appear when the request
that is passed to `webhook_signature_valid` does not have a valid
json body. This fixes a problem with swagger when the method
`webhook_signature_valid` was used in a DRF permission.